### PR TITLE
fix: ReferenceAudio 缓存未区分语言导致跨语种参考错配

### DIFF
--- a/src/genie_tts/Audio/ReferenceAudio.py
+++ b/src/genie_tts/Audio/ReferenceAudio.py
@@ -11,18 +11,20 @@ from typing import Optional, Dict
 
 
 class ReferenceAudio:
-    _prompt_cache: Dict[str, 'ReferenceAudio'] = LRUCacheDict(
+    _prompt_cache: Dict[tuple[str, str], 'ReferenceAudio'] = LRUCacheDict(
         capacity=int(os.getenv('Max_Cached_Reference_Audio', '10')))
 
     def __new__(cls, prompt_wav: str, prompt_text: str, language: str):
-        if prompt_wav in cls._prompt_cache:
-            instance = cls._prompt_cache[prompt_wav]
-            if instance.text != prompt_text:  # 如果文本与缓存内记录的不同，则更新。
+        cache_key = (prompt_wav, language)
+        if cache_key in cls._prompt_cache:
+            instance = cls._prompt_cache[cache_key]
+            # 如果文本或语言与缓存内记录的不同，则更新。
+            if instance.text != prompt_text or instance.language != language:
                 instance.set_text(prompt_text, language=language)
             return instance
 
         instance = super().__new__(cls)
-        cls._prompt_cache[prompt_wav] = instance
+        cls._prompt_cache[cache_key] = instance
         return instance
 
     def __init__(self, prompt_wav: str, prompt_text: str, language: str):
@@ -31,6 +33,7 @@ class ReferenceAudio:
 
         # 文本相关。
         self.text: str = prompt_text
+        self.language: str = language
         self.phonemes_seq: Optional[np.ndarray] = None
         self.text_bert: Optional[np.ndarray] = None
         self.set_text(prompt_text, language=language)
@@ -58,6 +61,7 @@ class ReferenceAudio:
 
     def set_text(self, prompt_text: str, language: str) -> None:
         self.text = prompt_text
+        self.language = language
         self.phonemes_seq, self.text_bert = get_phones_and_bert(prompt_text, language=language)
 
     @classmethod


### PR DESCRIPTION
## 问题背景
`ReferenceAudio` 的缓存 key 仅使用 `prompt_wav`（音频路径），未包含 `language`。
当同一参考音频在同一进程内用不同语言设置时，会复用第一次语言的 `phonemes_seq`/`text_bert`，导致跨语种推理错配。

## 触发条件
1. 同一进程内未重启
2. 同一 `audio_path` 被至少调用两次 `set_reference_audio()`
3. 第二次调用时 `language` 与第一次不同（显式传入或由模型语言隐式推导）

满足以上条件时，第二次调用会命中缓存并复用第一次语言的特征。

## 现象
跨语种推理时输出异常（语气词/重复参考文本等），且问题可通过脚本稳定复现。

## 解决方案
缓存 key 从 `prompt_wav` 改为 `(prompt_wav, language)`。
同时在语言变化时更新 `ReferenceAudio` 内部的 `phonemes_seq`/`text_bert`。

## 最小复现
```py
import genie_tts as genie

# 加载角色语音模型
genie.load_character(
    # ...
    language='zh',
)

# 第一次：语言=zh
genie.set_reference_audio(
    # ...
    audio_path=r"ref.wav",
    audio_text="xxx", # 日语
    # language 不传，自动用 zh
)

# 第二次：语言=jp
genie.set_reference_audio(
    # ...
    audio_path=r"ref.wav",
    audio_text="xxx", # 日语
    language="jp",
)

# 运行 TTS 推理并生成音频
text = "yyy" # 中文
genie.tts(
    # ...
    text=text,
    play=True,
    save_path="output.wav",
)

genie.wait_for_playback_done()  # 确保音频播放完成

print("🎉 Audio generation complete!")
```

## 影响范围
跨语种推理、多语言切换场景；对单语言单次推理无影响。

## 测试
- [x] 复现脚本验证
