### PR TITLE
refactor: 添加自动下载数据环境变量避免自动化场景阻塞

### DIFF
--- a/src/genie_tts/Core/Resources.py
+++ b/src/genie_tts/Core/Resources.py
@@ -103,11 +103,16 @@ ROBERTA_MODEL_DIR: str = os.getenv(
     f"{GENIE_DATA_DIR}/RoBERTa"
 )
 
+AUTO_DOWNLOAD = os.getenv("GENIE_AUTO_DOWNLOAD", "").lower() in ("1", "true", "y", "yes")
+
 if not os.path.exists(GENIE_DATA_DIR):
-    print("⚠️ GenieData folder not found.")
-    choice = input("Would you like to download it automatically from HuggingFace? (y/N): ").strip().lower()
-    if choice == "y":
+    if AUTO_DOWNLOAD:
         download_genie_data()
+    else:
+        print("Warning: GenieData folder not found.")
+        choice = input("Would you like to download it automatically from HuggingFace? (y/N): ").strip().lower()
+        if choice == "y":
+            download_genie_data()
 
 # ---- Run directory checks ----
 ensure_exists(HUBERT_MODEL_DIR, "HUBERT_MODEL_DIR")


### PR DESCRIPTION
# 动机

目前 `Resources.py` 会在未检测到 `GENIE_DATA_DIR` 对应路径时需要交互式确认是否下载数据，阻塞了主流程，可以通过环境变量与交互式输入优化自动化部署场景的体验。

# 改动范围

- 添加一个环境变量 `GENIE_AUTO_DOWNLOAD` 控制行为，在 `Resources.py` 中如果该环境变量存在，则会自动下载数据，否则回到通过终端提示并询问用户是否下载数据，确认后才进行下载。

# 影响范围

环境变量默认为空，因此默认行为保持不变，仍然是进入交互式确认分支。若在整合包或其他自动化场景中需要更新，则可以通过额外注入 `GENIE_AUTO_DOWNLOAD=1` 的环境变量实现自动化下载。

目前日志逻辑我没看到统一规范，因此在改动的时候将 `GENIE_AUTO_DOWNLOAD` 开启时连警告日志都不输出，以减小逻辑影响范围。如果有统一日志规范，我其实更倾向于把警告放在找不到 `GENIE_DATA_DIR` 时就自动触发。

# 备注

注意到现有文档对环境变量的描述不全，因此刻意不添加文档更新，一旦有需要，后续补充完环境变量文档即可追加。